### PR TITLE
Fix build error on windows

### DIFF
--- a/nvwa/mmap_reader_base.cpp
+++ b/nvwa/mmap_reader_base.cpp
@@ -208,7 +208,7 @@ bool mmap_reader_base::_open(const wchar_t* path, std::error_code* ecp)
         indicate_last_op_failure(ecp, "CreateFile");
         return false;
     }
-    return initialize(ecp);
+    return _initialize(ecp);
 }
 #endif // NVWA_WINDOWS
 


### PR DESCRIPTION
"initialize" doesn't exist, presumably it was changed at some point to "_initialize" but there is still one old instance left.